### PR TITLE
Multi-account/multi-intermediary (and base32)

### DIFF
--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -304,7 +304,7 @@ See {{delegated-examples}} for examples.
 
 There are use-cases where a user may wish to simultaneously use multiple intermediaries or multiple independent accounts with a provider.  For example, a hostname may be using a "multi-CDN" where the hostname simultaneously uses multiple Content Delivery Network (CDN) providers.
 
-To support this, providers may support prefixing the challenge with a label containing an unique account identifier of the form "\_<identifier-token>" and following the requirements of {{random-token}}, specified as either base32 or base16 encoded. This identifier token should be stable over time and would be provided to the user by the provider, or by an intermediary in the case where domain validation is delegated ({{delegated}}).
+To support this, providers may support prefixing the challenge with a label containing an unique account identifier of the form `_<identifier-token>` and following the requirements of {{random-token}}, specified as either base32 or base16 encoded. This identifier token should be stable over time and would be provided to the user by the provider, or by an intermediary in the case where domain validation is delegated ({{delegated}}).
 
 The resulting record could either directly contain a TXT record or a CNAME (as in {{delegated}}).  For example:
 

--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -46,6 +46,7 @@ normative:
 
 informative:
     RFC4086:
+    RFC4343:
     RFC8555:
     RFC9210:
     RFC6672:
@@ -269,7 +270,7 @@ The user SHOULD de-provision the resource record provisioned for DNS-based domai
 
 CNAME records MAY be used instead of TXT records, either for Delegated Domain Control Validation ({{delegated}}) or where specified by providers to support users who are unable to create TXT records.
 
-A provider supporting CNAME records MUST specify the use of an underscore-prefixed label (e.g., "\_foo-<token>" or even the less-recommended "\_<token>") as a CNAME MUST NOT be placed at the same domain name that is being validated. This is for the same reason already cited in {{pitfalls}}. CNAME records cannot co-exist with other data, and there may already be other record types that exist at the domain name. Instead, as with the TXT record recommendation, a provider specific label should be added as a subdomain of the domain to be verified. This ensures that the CNAME does not collide with other record types.
+A provider supporting CNAME records MUST specify the use of an underscore-prefixed label (e.g., `_foo-<token>` or even the less-recommended `_<token>`) as a CNAME MUST NOT be placed at the same domain name that is being validated. This is for the same reason already cited in {{pitfalls}}. CNAME records cannot co-exist with other data, and there may already be other record types that exist at the domain name. Instead, as with the TXT record recommendation, a provider specific label should be added as a subdomain of the domain to be verified. This ensures that the CNAME does not collide with other record types.
 
 In practice, many providers that employ CNAMEs for domain control validation today use a random subdomain label, which also works to avoid collisions. But adding an provider-specific component in addition (such as `_foo-<RANDOM>-challenge`) would make it easier for the domain owner to keep track of why and for what service a validation record has been deployed.
 


### PR DESCRIPTION
* Cover DCV supporting multiple intermediaries and multiple accounts
* Clarify either base32 or base16 for use in tokens in labels.
* Fix some markdown errors that crept in.