### PR TITLE
Address Duane's feedback

### DIFF
--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -267,7 +267,7 @@ The RECOMMENDED format for a Validation Record's owner name is as application-sp
 
 If an Application Service Provider has an application-specific need to have multiple validations for the same label, multiple prefixes can be used, such as "`_<FEATURE>._<PROVIDER_RELEVANT_NAME>-challenge`".
 
-An Application Service Provider may also specify prepending a random token to the owner name of a validation record, such as "`<RANDOM_TOKEN>._<PROVIDER_RELEVANT_NAME>-challenge`". This can be done either as part of the challenge itself ({{cname-dcv}}, to support multiple Intermediaries ({{multiple}}), or to make it harder for a third party to scan what Application Service Providers are being used by a given domain name.
+An Application Service Provider may also specify prepending a random token to the owner name of a validation record, such as "`<RANDOM_TOKEN>._<PROVIDER_RELEVANT_NAME>-challenge`". This can be done either as part of the challenge itself ({{cname-dcv}}), to support multiple Intermediaries ({{multiple}}), or to make it harder for a third party to scan what Application Service Providers are being used by a given domain name.
 
 ### Scope Indication {#scope-indication}
 

--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -207,11 +207,11 @@ A very common but unfortunate technique in use today is to employ a DNS TXT reco
 
 Since DNS resource record sets are treated atomically, a query for the Validation Record will return all TXT records in the response. There is no way for the verifier to specifically query only the TXT record that is pertinent to their application service. The verifier must obtain the aggregate response and search through it to find the specific record it is interested in.
 
-Additionally, placing many such TXT records at the same name increases the size of the DNS response. If the size of the UDP response (UDP being the most common DNS transport today) is large enough that it does not fit into the Path MTU of the network path, this may result in IP fragmentation, which often does not work reliably on the Internet today due to firewalls and middleboxes, and also is vulnerable to various attacks ([AVOID-FRAGMENTATION]). Depending on message size limits configured or being negotiated, it may alternatively cause the DNS server to "truncate" the UDP response and force the DNS client to re-try the query over TCP in order to get the full response. Not all networks properly transport DNS over TCP and some DNS software mistakenly believe TCP support is optional ([RFC9210]).
+Additionally, placing many such TXT records at the same name increases the size of the DNS response. If the size of the UDP response (UDP being the most common DNS transport today) is large enough that it does not fit into the Path MTU of the network path, this may result in IP fragmentation, which can be unreliable due to firewalls and middleboxes is vulnerable to various attacks ([AVOID-FRAGMENTATION]). Depending on message size limits configured or being negotiated, it may alternatively cause the DNS server to "truncate" the UDP response and force the DNS client to re-try the query over TCP in order to get the full response. Not all networks properly transport DNS over TCP and some DNS software mistakenly believe TCP support is optional ([RFC9210]).
 
 Other possible issues may occur. If a TXT record (or any other record type) is designed to be placed at the same domain name that is being validated, it may not be possible to do so if that name already has a CNAME record. This is because CNAME records cannot co-exist with other (non-DNSSEC) records at the same name. This situation cannot occur at the apex of a DNS zone, but can at a name deeper within the zone.
 
-When multiple distinct services create domain Validation Records with the same owner name, there is no way to delegate an application specific domain Validation Record to a third party. Furthermore, even without delegation, an organization may have a shared DNS zone where they need to provide record level permissions to the specific division within the organization that is responsible for the application in question. This can't be done if all applications expect to find validation records at the same name.
+When multiple distinct services specify placing Validation Records at the same owner name, there is no way to delegate an application specific domain Validation Record to a third party. Furthermore, even without delegation, an organization may have a shared DNS zone where they need to provide record level permissions to the specific division within the organization that is responsible for the application in question. This can't be done if all applications expect to find validation records at the same name.
 
 The presence of a Validation Record with a predictable domain name (either as a TXT record for the exact domain name where control is being validated or with a well-known label) can allow attackers to enumerate the utilized set of Application Service Providers.
 
@@ -237,10 +237,16 @@ Future specifications may provide better mechanisms or recommendations for defin
 
 All Domain Control Validation mechanisms are implemented by a resource record with:
 
-1) An owner name related to the domain name being validated
-2) One or more random tokens, to be placed in either the validation record's RDATA, in the target of a CNAME (or chain of CNAMEs), or as a label of the owner name.
+1) An owner name related to the domain name being validated, and
+2) One or more random tokens
 
-Both of these are issued to the User by either an Application Service Provider or an Intermediary. An issued random token then needs to exist in at least one of these to demonstrate the User has control over the domain name being validated. Variations on this approach exist to meet different uses.
+Both of these are issued to the User by either an Application Service Provider or an Intermediary. An issued random token then needs to exist in at least one of the following to demonstrate the User has control over the domain name being validated:
+
+1) Validation Record's RDATA
+2) The target of a CNAME (or chain of CNAMEs)
+3) Label of the owner name
+
+Variations on this approach exist to meet different uses.
 
 ## Random Token {#random-token}
 
@@ -275,7 +281,7 @@ The Application Service Provider will normally know which of these scoped DNS re
 
 Note that the ACME DNS challenge specification {{ACME-SCOPED-CHALLENGE}} has incorporated this scope indication format.
 
-Application owners SHOULD utilize the IANA "Underscored and Globally Scoped DNS Node Names" registry {{UNDERSCORE-REGISTRY}} to ensure that there are no collisions with existing entries.
+Application owners SHOULD utilize the IANA "Underscored and Globally Scoped DNS Node Names" registry {{UNDERSCORE-REGISTRY}} and avoid using underscore labels that already exist in the registry.
 
 ### CNAME Considerations {#cname-considerations}
 
@@ -340,7 +346,7 @@ The User SHOULD de-provision the resource record provisioned for DNS-based domai
 
 ## Delegated Domain Control Validation {#delegated}
 
-Delegated domain control validation lets a User delegate the domain control validation process for their domain to an Intermediary without having to hand over full DNS access.  It is a variation of the above TXT record validation ({{txt-record}}) that indirectly inserts a CNAME record prior to the TXT record.
+Delegated domain control validation lets a User delegate the domain control validation process for their domain to an Intermediary without granting the Intermediary the ability to make changes to their domain or zone configuration.  It is a variation of the above TXT record validation ({{txt-record}}) that indirectly inserts a CNAME record prior to the TXT record.
 
 The Intermediary gives the User a CNAME record to add for the domain and Application Service Provider being validated that points to the Intermediary's domain, where the actual validation TXT record is placed. The record name and base16-encoded (or base32-encoded) random tokens are generated as in {{random-token}}. For example:
 
@@ -350,7 +356,7 @@ The Intermediary then adds the actual Validation Record in a domain they control
 
     <intermediary-random-token>.dcv.intermediary.example.  IN   TXT "<provider-random-token>"
 
-Such a setup is especially useful when the Application Service Provider wants to periodically re-issue the challenge with a new provider random token. CNAMEs allow automating the renewal process by letting the Intermediary place the random token in their DNS instead of needing continuous write access to the User's DNS.
+Such a setup is especially useful when the Application Service Provider wants to periodically re-issue the challenge with a new provider random token. CNAMEs allow automating the renewal process by letting the Intermediary place the random token in their DNS zone instead of needing continuous write access to the User's DNS.
 
 Importantly, the CNAME record target also contains a random token issued by the Intermediary to the User (preferably over a secure channel) which proves to the Intermediary that example.com is controlled by the User. The Intermediary must keep an association of Users and domain names to the associated Intermediary-random-tokens. Without a linkage validated by the Intermediary during provisioning and renewal there is the risk that an attacker could leverage a "dangling CNAME" to perform a "subdomain takeover" attack ({{SUBDOMAIN-TAKEOVER}}).
 
@@ -378,7 +384,7 @@ Application Service Providers may wish to always prepend the `_<identifier-token
 
 ## Specification of Validation Records
 
-Validation Records need to be securely relayed from an Application Service Provider to a DNS administrator. Application Service Providers and intermediaries SHOULD offer detailed and easily-accessible help pages, keeping in mind that the DNS administrator might not have a login account on the website of the Application Service Provider or Intermediary. Similarly, for clarity, the entire DNS resource record (RR) using the Fully Qualified Domain Name to be added SHOULD be provided along with help instructions.  Where possible, APIs SHOULD be used to relay instructions.
+Validation Records need to be securely relayed from an Application Service Provider to a DNS administrator. Application Service Providers and Intermediaries SHOULD offer detailed and easily-accessible help pages, keeping in mind that the DNS administrator might not have a login account on the website of the Application Service Provider or Intermediary. Similarly, for clarity, the entire DNS resource record (RR) using the Fully Qualified Domain Name to be added SHOULD be provided along with help instructions.  Where possible, APIs SHOULD be used to relay instructions.
 
 ## Time-bound checking
 
@@ -394,15 +400,15 @@ The TTL {{RFC1034}} for Validation Records SHOULD be short to allow recovering f
 
 The Application Service Provider looking up a Validation Record may have to wait for up to the SOA minimum TTL (negative caching TTL) of the enclosing zone for the record to become visible, if it has been previously queried. If the application User wants to make the Validation Record visible more quickly they may need to work with the DNS administrator to see if they are willing to lower the SOA minimum TTL (which has implications across the entire zone).
 
-Application Service Provider's verifiers MAY wish to either use dedicated DNS resolvers configured with a low maximum negative caching TTL or flush Validation Records from resolver caches prior to issuing queries.
+Application Service Providers' verifiers MAY wish to use dedicated DNS resolvers configured with a low maximum negative caching TTL, flush Validation Records from resolver caches prior to issuing queries or just directly query authoritative name servers to avoid caching.
 
 ## CNAME Records for Domain Control Validation {#cname-dcv}
 
-CNAME records MAY be used instead of TXT records where specified by Application Service Providers to support Users who are unable to create TXT records. Two forms of this are common: including the challenge token in the owner name of a validation record, or including the challenge token as a part of the CNAME target. This approach has a number of limitatations relative to using TXT records.
+CNAME records MAY be used instead of TXT records where specified by Application Service Providers to support Users who are unable to create TXT records. Two forms of this are common: including the random token in the owner name of a validation record, or including the random token as a part of the CNAME target. This approach has a number of limitations relative to using TXT records.
 
-### Random Token in Domain Names
+### Random Token in Owner Names
 
-Application Service Providers MAY specify that a random token be included in the owner name of a validation record.  In this case an underscore-prefixed label MUST be used (e.g., `_<token>._foo` or `_foo-<token>`). The resource record is then a CNAME to a domain name specified by the Application Service Provider. The Application Service Provider uses the presence of a resource record at the CNAME target to perform the validation, validating the both presence of the record as well as the CNAME target. For example:
+Application Service Providers MAY specify that a random token be included in the owner name of a validation record.  In this case an underscore-prefixed label MUST be used (e.g., `_<token>._foo` or `_foo-<token>`). The resource record is then a CNAME to a domain name specified by the Application Service Provider. The Application Service Provider uses the presence of a resource record at the CNAME target to perform the validation, validating the both presence of the record as well as the CNAME target. The CNAME target of the Validation Record MUST exist in order to verify the domain. For example:
 
     _<random-token>._foo-challenge.example.com.  IN   CNAME dcv.provider.example.
 


### PR DESCRIPTION
Fix #143
Thanks @wessels for the feedback and @enygren for raising #143, super helpful.

Notes:

> > Depending on message size limits configured or being negotiated, it
> > may alternatively cause the DNS server to "truncate" the UDP response
> > and force the DNS client to re-try the query over TCP in order to get
> > the full response. Not all networks properly transport DNS over TCP
> > and some DNS software mistakenly believe TCP support is optional
> > ([RFC9210]).
> 
> I have mixed feelings about this.  While perhaps factually true, I think broken DNS-over-TCP shouldn’t be a reason for not lumping validation records together.  There are other valid reasons to avoid that practice and networks with broken DNS-over-TCP shouldn’t be coddled.

I didn't address this since this section in the document just describes Common Pitfalls related to domain validation and doesn't (and shouldn't need to) comment on whether the pitfalls should exist in the first place.

> > The presence of a Validation Record with a predictable domain name
> > (either as a TXT record for the exact domain name where control is
> > being validated or with a well-known label) can allow attackers to
> > enumerate utilized set of Application Service Providers.
> 
> Not sure I buy this argument.  Doesn’t the draft recommend using predictable names anyway, just one per provider?

It does, but we discuss in section 5.2 (last para) how this pitfall can be addressed i.e. by "prepending a random token to the owner name of a validation record".
 
> > APIs SHOULD be used to relay instructions.
> 
> Not sure I follow this.  An API to relay instructions?

I'm not sure about this either. cc @enygren who asked for this text.

