### PR TITLE
Suggestion on trimming examples

### DIFF
--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -236,25 +236,13 @@ Application Service Providers MUST provide clear instructions on how long the ch
 
 The instructions for validity duration MAY be encoded in the RDATA as token metadata ({{metadata}} using the key "expiry" to hold a time after which it is safe to remove the Validation Record. For example:
 
-    _example_service-challenge.example.com.  IN   TXT  "token=3419...3d206c4 expiry=2023-02-08T02:03:19+00:00"
+    _example_service-challenge.example.com.  IN   TXT  "token=3419...3d206c4 expiry=2023-02-08"
 
 When an expiry time is specified, the value of "expiry" SHALL be in ISO 8601 format as specified in {{!RFC3339, Section 5.6}}.
 
-A simpler variation of the expiry time is also ISO 8601 valid and can also be specified, using the "full-date" format. For example:
+Alternatively, if the record should never expire (for instance, persistent validations that are checked periodically by the Application Service Provider) and should not be removed, the "expiry" key SHALL be set as "expiry=never". 
 
-    _example_service-challenge.example.com.  IN   TXT  "token=3419...3d206c4 expiry=2023-02-08"
-
-Alternatively, if the record should never expire (for instance, persistent validations that are checked periodically by the Application Service Provider) and should not be removed, the key "expiry" SHALL be set to have value "never".
-
-    _example_service-challenge.example.com.  IN   TXT  "token=3419...3d206c4 expiry=never"
-
-The "expiry" key MAY be omitted in cases where the Application Service Provider has clarified the record expiry policy out-of-band.
-
-    _example_service-challenge.example.com.  IN   TXT  "token=3419...3d206c4"
-
-Note that this is semantically the same as:
-
-    _example_service-challenge.example.com.  IN   TXT  "3419...3d206c4"
+The "expiry" key MAY be omitted in cases where the Application Service Provider has clarified the record expiry policy out-of-band.  In this case, the RDATA is set to "token=3419...3d206c4". This is semantically identical to "3419...3d206c4".
 
 The User SHOULD de-provision the resource record provisioned for DNS-based domain control validation once it is no longer required.
 


### PR DESCRIPTION
I have a note on the need to trim down the examples, so this is a first pass

removed the full RFC3339 example, but left the reference

removed the example of "expiry=never" and referenced the RDATA

reduced the examples of "token=" to mention what the RDATA has

I think it may one example too many removedl