### PR TITLE
Fix the indentation for the ABNF grammar, so it is correctly displayed

### DIFF
--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -186,15 +186,15 @@ The token MUST be the first element in the key-value list. If the TXT record RDA
 
 Keys are considered to be case-insensitive. Each Validation Record consists of RDATA for val-record with the following grammar (with an ABNF per {{RFC5234}}):
 
-  val-record     = keyvalue-list
-  keyvalue-list  = keyvalue-pair *( SP keyvalue-pair )
-  keyvalue-pair  = key "=" value
+    val-record     = keyvalue-list
+    keyvalue-list  = keyvalue-pair *( SP keyvalue-pair )
+    keyvalue-pair  = key "=" value
 
-  key            = 1*key-char
-  key-char       = ALPHA / DIGIT / "-" / "_"
+    key            = 1*key-char
+    key-char       = ALPHA / DIGIT / "-" / "_"
 
-  value          = *value-char
-  value-char    = ALPHA / DIGIT / "+" / "/" / "=" / ":" / "+" / "-" / "_"
+    value          = *value-char
+    value-char    = ALPHA / DIGIT / "+" / "/" / "=" / ":" / "+" / "-" / "_"
 
 If an alternate syntax is used by the Application Service Provider for token metadata, they MUST specify a grammar for it.
 


### PR DESCRIPTION
The currenty indentation (of 2 spaces) creates a difficult to read ABNF section. By using 4 spaces, it will be formatted as a code block, which makes it better to read.