### PR TITLE
DNSSEC validation updates

### DIFF
--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -48,6 +48,7 @@ normative:
   RFC2119:
   RFC8174:
   RFC9364:
+  RFC4035:
 
 informative:
     RFC5234:
@@ -336,9 +337,10 @@ Application Service Providers and intermediaries should use authenticated channe
 
 A domain owner SHOULD sign their DNS zone using DNSSEC {{RFC9364}} to protect Validation Records against DNS spoofing attacks, including from on-path attackers.
 
-DNSSEC validation SHOULD be performed by Application Service Providers that verify Validation Records they have requested to be deployed.
+Application Service Providers MUST use a trusted DNSSEC validating resolver to verify Validation Records they have requested to be deployed. When the AD bit ({{RFC4035}} Section 3.2.3) is not set in DNS responses for Validation Records, Application Service Providers SHOULD take additional steps to reduce an attacker's ability to complete a challenge by spoofing DNS:
 
-If no DNSSEC support is detected for the domain being validated, or if DNSSEC validation cannot be performed, Application Service Providers SHOULD attempt to query and confirm the Validation Record by matching responses from multiple DNS resolvers on unpredictable geographically diverse IP addresses to reduce an attacker's ability to complete a challenge by spoofing DNS. Alternatively, Application Service Providers MAY perform multiple queries spread out over a longer time period to reduce the chance of receiving spoofed DNS answers.
+* Application Service Prociders SHOULD attempt to query and confirm the Validation Record by matching responses from multiple DNS resolvers on unpredictable geographically diverse IP addresses
+* Application Service Providers MAY perform multiple queries spread out over a longer time period to reduce the chance of receiving spoofed DNS answers.
 
 DNS Spoofing attacks are easier in the case of persistent validation as the expected result is publically known. For example, absent DNSSEC this could allow an on-path attacker to bypass a revocation by continuing to return a record that the DNS Operator had removed from the zone.
 


### PR DESCRIPTION
Switch DNSSEC validation to MUST and be clear that lack of AD bit inresponse is signal to do additional checks

Fixes #182
1) shifts ASPs using a validating DNSSEC resolver from "SHOULD" to "MUST" 
2) specifies that the resolver here should be "trusted" (do we need to define this and clarify that a secure channel to it must be used?) 
3) is more specific that absence of the AD bit in the response is the reason to take additional steps (vs the current less specific text of "If no DNSSEC support is detected for the domain being validated, or if DNSSEC validation cannot be performed")