### PR TITLE
Switch from random tokens to Unique Tokens

### DIFF
--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -50,6 +50,7 @@ normative:
   RFC9364:
 
 informative:
+    RFC3986:
     RFC5234:
     RFC4086:
     RFC4343:
@@ -135,7 +136,7 @@ This document recommends using TXT based domain control validation in a way that
 
 * `Unique Token`: a value that uniquely identifies the DNS domain control validation challenge, defined in {{unique-token}}. Unique Tokens are constructed by the Application Service Provider in a way that guarantees uniqueness within the scope of the challenge, such as a random value.
 
-* `Identifier Token`: a form of Unique Token described in {{multiple]} which is prefixed to the Validation Record name to multiple Intermediaries or a distinct RRset per Application Service Provider. 
+* `Identifier Token`: a form of Unique Token described in {{multiple}} which is prefixed to the Validation Record name to multiple Intermediaries or a distinct RRset per Application Service Provider.
 
 # Purpose of Domain Control Validation {#purpose}
 


### PR DESCRIPTION
Switches from "random tokens" to "unique tokens", of which one type is random, as discussed in Madrid.
Fixes #161 and closes the largest gap preventing this from obviating draft-sheth-identifiers-dns-00 (#189).
One type of unique tokens is a random token.
Also updates security and privacy considerations accordingly.