### PR TITLE
Remove "MUST" requirement for 128 bits of entropy.

### DIFF
--- a/draft-ietf-dnsop-domain-verification-techniques.md
+++ b/draft-ietf-dnsop-domain-verification-techniques.md
@@ -279,8 +279,7 @@ If token values aren't long enough, lack adequate entropy, or are not unique the
 
 Application Service Providers MUST evaluate the threat model for their particular application to determine a token construction mechanism that guarantees uniqueness and meets their security requirements.
 
-When Random Tokens are used, they MUST be constructed in a way that does not have collisions and is not predictable (see {{RFC4086}}).
-
+When Random Tokens are used, they MUST be constructed in a way that provides sufficient unpredictability to avoid collisions and brute force attacks.
 
 ## Service Confusion {#service-confusion}
 


### PR DESCRIPTION
Partially addresses #199 

(Adding a threat model is a much larger effort and should be a separate PR.)